### PR TITLE
Add Log escalation failure if SF bot is offline/disabled

### DIFF
--- a/lib/Room.ts
+++ b/lib/Room.ts
@@ -93,7 +93,7 @@ export const performHandover = async (modify: IModify, read: IRead, rid: string,
             targetDepartment: livechatTransferData.targetDepartment
         }
 
-        console.log('Failed to handover', handoverFailure);
+        console.log('Failed to handover', JSON.stringify(handoverFailure));
 
         await createMessage(rid, read, modify, { text: offlineMessage ? offlineMessage : DefaultMessage.DEFAULT_DialogflowHandoverFailedMessage });
 

--- a/lib/Room.ts
+++ b/lib/Room.ts
@@ -84,7 +84,16 @@ export const performHandover = async (modify: IModify, read: IRead, rid: string,
             throw new Error(`${Logs.HANDOVER_REQUEST_FAILED_ERROR} ${error}`);
         });
     if (!result) {
-        const offlineMessage: string = await getAppSettingValue(read, AppSetting.DialogflowServiceUnavailableMessage);
+        const offlineMessage: string = await getAppSettingValue(read, AppSetting.DialogflowServiceUnavailableMessage),
+        handoverFailure = {
+            error: offlineMessage,
+            errorMessage: 'Unable to reach Liveagent bot, it may be offline or disabled.',
+            dialogflow_SessionID: rid,
+            visitorDetails: (({ id, token }) => ({ id, token }))(visitor),
+            targetDepartment: livechatTransferData.targetDepartment
+        }
+
+        console.log('Failed to handover', handoverFailure);
 
         await createMessage(rid, read, modify, { text: offlineMessage ? offlineMessage : DefaultMessage.DEFAULT_DialogflowHandoverFailedMessage });
 


### PR DESCRIPTION
### This PR contains the log escalation failure if SF bot is offline/disabled:

#### Steps to reproduce these changes
1. Make sure that Salesforce Bot is offline, if not log out from the Salesforce bot.
2. Disabling the bot will have a similar effect as it will make the bot offline.
3. That's it, now try to escalate the case from livechat widget.
4. It should fail and log the error **Failed to handover**, as shown below

#### Screenshot of the logpoint

![image](https://user-images.githubusercontent.com/24320496/115404494-0197d600-a20b-11eb-9662-df558dcb733e.png)


