### PR TITLE
[FIX] passing Custom Fields as Query Params in CX

### DIFF
--- a/lib/Dialogflow.ts
+++ b/lib/Dialogflow.ts
@@ -39,10 +39,15 @@ class DialogflowClass {
             };
 
             const queryParams = {
-                timeZone: 'America/Los_Angeles', parameters:  {
+                timeZone: 'America/Los_Angeles',
+                parameters:  {
                     username: room.visitor.username,
                 },
             };
+
+            if (requestType === DialogflowRequestType.EVENT && typeof request !== 'string') {
+                queryParams.parameters = {...queryParams.parameters, ...(request.parameters ? request.parameters : {})};
+            }
 
             const accessToken = await this.getAccessToken(read, modify, http, sessionId);
             if (!accessToken) { throw Error(Logs.ACCESS_TOKEN_ERROR); }


### PR DESCRIPTION
Closes https://github.com/WideChat/Rocket.Chat/issues/899

@chadgoss Now we are getting `roomId` and `visitorToken` in queryParams

<img width="1790" alt="Screenshot 2021-08-24 at 10 38 53 PM" src="https://user-images.githubusercontent.com/18264684/130660613-528ff7af-2ace-4674-a717-7feb3eebc4f7.png">
