### PR TITLE
Add the Room ID to rest api console.error

### DIFF
--- a/endpoints/IncomingEndpoint.ts
+++ b/endpoints/IncomingEndpoint.ts
@@ -72,9 +72,10 @@ export class IncomingEndpoint extends ApiEndpoint {
                     await createDialogflowMessage(sessionId, read, modify, response, this.app);
                     await handlePayloadActions(this.app, read, modify, http, persistence, sessionId, vToken, response);
                 } catch (error) {
-                    this.app.getLogger().error(`${Logs.DIALOGFLOW_REST_API_ERROR} ${getError(error)}`);
-                    console.error(`${Logs.DIALOGFLOW_REST_API_ERROR} ${getError(error)}`);
-                    throw new Error(`${Logs.DIALOGFLOW_REST_API_ERROR} ${getError(error)}`);
+                    const errorContent = `${Logs.DIALOGFLOW_REST_API_ERROR}: { roomID: ${sessionId} } ${getError(error)}`;
+                    this.app.getLogger().error(errorContent);
+                    console.error(errorContent);
+                    throw new Error(errorContent);
                 }
                 break;
             case EndpointActionNames.SEND_MESSAGE:

--- a/handler/PostMessageSentHandler.ts
+++ b/handler/PostMessageSentHandler.ts
@@ -92,8 +92,9 @@ export class PostMessageSentHandler {
             await botTypingListener(this.modify, rid, DialogflowBotUsername);
             response = (await Dialogflow.sendRequest(this.http, this.read, this.modify, rid, text, DialogflowRequestType.MESSAGE));
         } catch (error) {
-            this.app.getLogger().error(`${Logs.DIALOGFLOW_REST_API_ERROR} ${getErrorMessage(error)}`);
-            console.error(`${Logs.DIALOGFLOW_REST_API_ERROR} ${getErrorMessage(error)}`);
+            const errorContent = `${Logs.DIALOGFLOW_REST_API_ERROR}: { roomID: ${rid} } ${getErrorMessage(error)}`;
+            this.app.getLogger().error(errorContent);
+            console.error(errorContent);
 
             const serviceUnavailable: string = await getAppSettingValue(this.read, AppSetting.DialogflowServiceUnavailableMessage);
             await createMessage(rid, this.read, this.modify, { text: serviceUnavailable }, this.app);
@@ -163,8 +164,9 @@ export class PostMessageSentHandler {
                     languageCode: data.custom_languageCode || defaultLanguageCode || LanguageCode.EN,
                 }, DialogflowRequestType.EVENT));
             } catch (error) {
-                this.app.getLogger().error(`${Logs.DIALOGFLOW_REST_API_ERROR} ${getErrorMessage(error)}`);
-                console.error(`${Logs.DIALOGFLOW_REST_API_ERROR} ${getErrorMessage(error)}`);
+                const errorContent = `${Logs.DIALOGFLOW_REST_API_ERROR}: { roomID: ${rid} } ${getErrorMessage(error)}`;
+                this.app.getLogger().error(errorContent);
+                console.error(errorContent);
             }
         }
     }

--- a/lib/Dialogflow.ts
+++ b/lib/Dialogflow.ts
@@ -58,7 +58,7 @@ class DialogflowClass {
             } catch (error) {
                 const errorContent = `${Logs.HTTP_REQUEST_ERROR}: { roomID: ${sessionId} } ${getError(error)}`;
                 console.error(errorContent);
-                throw new Error(errorContent);
+                throw new Error(error);
             }
         } else {
 
@@ -83,7 +83,7 @@ class DialogflowClass {
             } catch (error) {
                 const errorContent = `${Logs.HTTP_REQUEST_ERROR}: { roomID: ${sessionId} } ${getError(error)}`;
                 console.error(errorContent);
-                throw new Error(errorContent);
+                throw new Error(error);
             }
         }
     }
@@ -130,7 +130,7 @@ class DialogflowClass {
         } catch (error) {
             const errorContent = `${Logs.HTTP_REQUEST_ERROR}: { roomID: ${sessionId || 'N/A'} } ${getError(error)}`;
             console.error(errorContent);
-            throw new Error(errorContent);
+            throw new Error(error);
         }
     }
 

--- a/lib/sendWelcomeEvent.ts
+++ b/lib/sendWelcomeEvent.ts
@@ -30,7 +30,7 @@ export const sendWelcomeEventToDialogFlow = async (app: IApp, read: IRead,  modi
         const response: IDialogflowMessage = await Dialogflow.sendRequest(http, read, modify, rid, event, DialogflowRequestType.EVENT);
         await createDialogflowMessage(rid, read, modify, response, app);
     } catch (error) {
-        console.error(`${Logs.DIALOGFLOW_REST_API_ERROR} ${getError(error)}`);
+        console.error(`${Logs.DIALOGFLOW_REST_API_ERROR}: { roomID: ${rid} } ${getError(error)}`);
         const serviceUnavailable: string = await getAppSettingValue(read, AppSetting.DialogflowServiceUnavailableMessage);
         await createMessage(rid, read, modify, { text: serviceUnavailable }, app);
         return;


### PR DESCRIPTION
The Room ID is now added to all occurrences of:

- `HTTP_REQUEST_ERROR`
- `DIALOGFLOW_REST_API_ERROR`
- `INVALID_RESPONSE_FROM_DIALOGFLOW`
- `INVALID_RESPONSE_FROM_DIALOGFLOW_CONTENT_UNDEFINED`

Except it was not possible at one occurrence of `HTTP_REQUEST_ERROR`, i.e in file `OnSettingUpdatedHandler` at this [position](https://github.com/WideChat/Apps.Dialogflow/blob/a33859ce0a0c18ccfee13a4877673c4dc610e958/handler/OnSettingUpdatedHandler.ts#L28).