### PR TITLE
[ FIX] Changed API call for custom environments

### DIFF
--- a/config/Settings.ts
+++ b/config/Settings.ts
@@ -9,6 +9,7 @@ export enum AppSetting {
     DialogflowClientEmail = 'dialogflow_client_email',
     DialogFlowPrivateKey = 'dialogflow_private_key',
     DialogflowEnvironment = 'dialogflow_environment',
+    DialogflowEnvironmentId = 'dialogflow_environment_id',
     DialogflowDefaultLanguage = 'dialogflow_default_language',
     DialogflowFallbackResponsesLimit = 'dialogflow_fallback_responses_limit',
     FallbackTargetDepartment = 'fallback_target_department',
@@ -110,6 +111,15 @@ export const settings: Array<ISetting> = [
         packageValue: 'draft',
         i18nLabel: 'dialogflow_environment',
         i18nDescription: 'dialogflow_environment_description',
+        required: false,
+    },
+    {
+        id: AppSetting.DialogflowEnvironmentId,
+        public: true,
+        type: SettingType.STRING,
+        packageValue: 'draft',
+        i18nLabel: 'dialogflow_environment_id',
+        i18nDescription: 'dialogflow_environment_id_description',
         required: false,
     },
     {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -15,6 +15,8 @@
     "dialogflow_private_key": "Private Key",
     "dialogflow_environment": "Environment",
     "dialogflow_environment_description": "Name of the Dialogflow environment. Default environment is draft",
+    "dialogflow_environment_id": "[CX ONLY] Environment ID",
+    "dialogflow_environment_id_description": "CX accepts the environment ID instead of the environment name for all environments other than `draft` \n 1. Go to the Dialogflow CX console. \n 2. Select the project. \n 3. Select agent. \n 4. Go to Environments and select 'Copy environment name to clipboard'. \n 5. The environment ID has the following format: \n 6. `projects/PROJECT_ID/locations/REGION_ID/agents/AGENT_ID/environments/ENVIRONMENT_ID`. \n 7. Copy `ENVIRONMENT_ID` and paste it here. \n 8. Write `draft` for default environment.",
     "dialogflow_fallback_responses_limit": "Fallback Responses Limit",
     "dialogflow_fallback_responses_limit_description": "The app will automatically trigger handover if consecutive fallback intents are triggered N no of times. This setting defines this value N",
     "target_department_for_handover": "Target Department for Handover",

--- a/lib/Dialogflow.ts
+++ b/lib/Dialogflow.ts
@@ -334,6 +334,7 @@ class DialogflowClass {
         const projectId = projectIds.length >= botId ? projectIds[botId - 1] : projectIds[0];
         const environments = (await getAppSettingValue(read, AppSetting.DialogflowEnvironment)).split(',');
         const environment = environments.length >= botId ? environments[botId - 1] : environments[0];
+        const environmentId = await getAppSettingValue(read, AppSetting.DialogflowEnvironmentId);
         const dialogFlowVersion = await getAppSettingValue(read, AppSetting.DialogflowVersion);
 
         if (dialogFlowVersion === 'CX') {
@@ -341,7 +342,7 @@ class DialogflowClass {
             const regionId = await getAppSettingValue(read, AppSetting.DialogflowRegion);
             const agentId = await getAppSettingValue(read, AppSetting.DialogflowAgentId);
 
-            return `https://${regionId}-dialogflow.googleapis.com/v3/projects/${projectId}/locations/${regionId}/agents/${agentId}/sessions/${sessionId}:detectIntent`;
+            return `https://${regionId}-dialogflow.googleapis.com/v3/projects/${projectId}/locations/${regionId}/agents/${agentId}/environments/${environmentId || 'draft'}/sessions/${sessionId}:detectIntent`;
         }
 
         const accessToken = await this.getAccessToken(read, modify, http, sessionId);


### PR DESCRIPTION
### Issue
Standard API call does not account for custom environments can defaults to `draft`.

### Changes
- Changed API url to account for custom environments.
- Added app setting for custom environment ID **(CX ONLY )**. 

### Details
CX accepts the environment ID instead of the environment name, for all environments other than `draft` 
1. Go to the Dialogflow CX console. 
2. Select the project. 
3. Select agent. 
4. Go to Environments and select 'Copy environment name to clipboard'. 
5. The environment ID has the following format:  
 `projects/PROJECT_ID/locations/REGION_ID/agents/AGENT_ID/environments/ENVIRONMENT_ID`. 
7. Copy `ENVIRONMENT_ID` and paste it in [CX ONLY] Environment ID
![image](https://user-images.githubusercontent.com/18405180/136454303-6e0e4446-98cc-4d7c-9cf8-9510108bca1a.png)
8. Alternatively, write `draft` for default environment.