### PR TITLE
Add prechat data from handover payload to room custom field

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,5 +19,5 @@
         "IPostLivechatRoomClosed",
         "IUIKitLivechatInteractionHandler"
     ],
-    "commitHash": "47a27ed35ee6fe974a5043fe82d49b6866a63827"
+    "commitHash": "dc5c39f7d7d14c159eef40ebd6bafba1de1281c0"
 }

--- a/lib/payloadAction.ts
+++ b/lib/payloadAction.ts
@@ -38,6 +38,9 @@ export const  handlePayloadActions = async (app: IApp, read: IRead,  modify: IMo
                         if (params.customDetail) {
                             customFields.customDetail = params.customDetail;
                         }
+                        if (params.prechatDetails) {
+                            customFields.prechatDetails = params.prechatDetails;
+                        }
                         const livechatRoom = await read.getRoomReader().getById(rid) as ILivechatRoom;
                         if (livechatRoom.customFields) {
                             customFields.appVersion = livechatRoom.customFields.appVersion;


### PR DESCRIPTION
Closes: https://github.com/WideChat/Rocket.Chat/issues/1119

Modification to the payload

```
{
  "action": {
    "name": "df_perform_handover",
    "params": {
      "customDetail": "{\"label\": \"BotTranscript__c\", \"value\": \"<p><strong>User</strong>: Test</p> <p><strong>Bot</strong>: Lets troubleshoot</p> <p><strong>User</strong>: Great!</p>\", \"entityMaps\": [{\"entityName\": \"LiveChatTranscript\", \"fieldName\": \"BotTranscript__c\"}], \"transcriptFields\": [\"BotTranscript__c\"], \"displayToAgent\": true}",
      "salesforceId": "5725g000000c6gk",
      "salesforceButtonId": "5735g000000c9FA",
     "prechatDetails":<Add prechat data here>,
    }
  }
}
```